### PR TITLE
[iOS] Adding VerificationResult field to CustomerInfo Entitlements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "accessibilitysnapshot",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/AccessibilitySnapshot.git",
-      "state" : {
-        "revision" : "54046d8fa44b9fa9f0e2229526f6ed89cb5e0ec2",
-        "version" : "1.0.2"
-      }
-    },
-    {
       "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
-        "version" : "2.1.2"
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
       }
     },
     {
@@ -23,17 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
-        "version" : "2.1.2"
-      }
-    },
-    {
-      "identity" : "flyingfox",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swhitty/FlyingFox.git",
-      "state" : {
-        "revision" : "f7829d4aca8cbfecb410a1cce872b1b045224aa1",
-        "version" : "0.16.0"
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
       }
     },
     {
@@ -42,24 +24,6 @@
       "location" : "https://github.com/quick/nimble",
       "state" : {
         "revision" : "1f3bde57bde12f5e7b07909848c071e9b73d6edc"
-      }
-    },
-    {
-      "identity" : "ohhttpstubs",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AliSoftware/OHHTTPStubs.git",
-      "state" : {
-        "revision" : "12f19662426d0434d6c330c6974d53e2eb10ecd9",
-        "version" : "9.1.0"
-      }
-    },
-    {
-      "identity" : "snapshotpreviews",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/EmergeTools/SnapshotPreviews.git",
-      "state" : {
-        "revision" : "e29969072e600518867af25d4d2acd0d1d2ffd5f",
-        "version" : "0.10.20"
       }
     },
     {

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -180,9 +180,11 @@ public typealias ProductIdentifier = String
     /// Initializes a `CustomerInfo` with the underlying data in the current schema version
     convenience init(response: CustomerInfoResponse,
                      entitlementVerification: VerificationResult,
+                     entitlementVerificationReason: VerificationReason?,
                      sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
         self.init(data: .init(response: response,
                               entitlementVerification: entitlementVerification,
+                              entitlementVerificationReason: entitlementVerificationReason,
                               schemaVersion: Self.currentSchemaVersion),
                   sandboxEnvironmentDetector: sandboxEnvironmentDetector)
     }
@@ -206,7 +208,8 @@ public typealias ProductIdentifier = String
             purchases: subscriber.allPurchasesByProductId,
             requestDate: response.requestDate,
             sandboxEnvironmentDetector: sandboxEnvironmentDetector,
-            verification: data.entitlementVerification
+            verification: data.entitlementVerification,
+            verificationReason: data.entitlementVerificationReason
         )
         self.nonSubscriptions = TransactionsFactory.nonSubscriptionTransactions(
             withSubscriptionsData: subscriber.nonSubscriptions
@@ -280,11 +283,12 @@ extension CustomerInfo {
 extension CustomerInfo {
 
     /// Creates a copy of this ``CustomerInfo`` modifying only the ``VerificationResult``.
-    func copy(with entitlementVerification: VerificationResult) -> Self {
+    func copy(with entitlementVerification: VerificationResult, entitlementVerificationReason: VerificationReason?) -> Self {
         guard entitlementVerification != self.data.entitlementVerification else { return self }
 
         var copy = self.data
         copy.entitlementVerification = entitlementVerification
+        copy.entitlementVerificationReason = entitlementVerificationReason
         return .init(data: copy)
     }
 
@@ -355,13 +359,16 @@ private extension CustomerInfo {
 
         var response: CustomerInfoResponse
         var entitlementVerification: VerificationResult
+        var entitlementVerificationReason: VerificationReason?
         var schemaVersion: String?
 
         init(response: CustomerInfoResponse,
              entitlementVerification: VerificationResult,
+             entitlementVerificationReason: VerificationReason?,
              schemaVersion: String?) {
             self.response = response
             self.entitlementVerification = entitlementVerification
+            self.entitlementVerificationReason = entitlementVerificationReason
             self.schemaVersion = schemaVersion
         }
 

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -95,7 +95,8 @@ class ETagManager {
                 self.storeIfPossible(newResponse, for: request)
                 return newResponse.asResponse(withRequestDate: response.requestDate,
                                               headers: response.responseHeaders,
-                                              responseVerificationResult: response.verificationResult)
+                                              responseVerificationResult: response.verificationResult,
+                                              responseVerificationReason: response.verificationReason)
             }
             if retried {
                 Logger.warn(
@@ -254,7 +255,8 @@ extension ETagManager.Response {
     fileprivate func asResponse(
         withRequestDate requestDate: Date?,
         headers: HTTPClient.ResponseHeaders,
-        responseVerificationResult: VerificationResult
+        responseVerificationResult: VerificationResult,
+        responseVerificationReason: VerificationReason?
     ) -> VerifiedHTTPResponse<Data> {
         return HTTPResponse(
             httpStatusCode: self.statusCode,
@@ -263,7 +265,7 @@ extension ETagManager.Response {
             requestDate: requestDate,
             origin: .cache
         )
-        .verified(with: responseVerificationResult)
+        .verified(with: responseVerificationResult, verificationReason: responseVerificationReason)
     }
 
     fileprivate func withUpdatedValidationTime() -> Self {

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -70,10 +70,12 @@ struct VerifiedHTTPResponse<Body: HTTPResponseBody>: HTTPResponseType {
 
     var response: HTTPResponse<Body>
     var verificationResult: VerificationResult
+    var verificationReason: VerificationReason?
 
-    init(response: HTTPResponse<Body>, verificationResult: VerificationResult) {
+    init(response: HTTPResponse<Body>, verificationResult: VerificationResult, verificationReason: VerificationReason?) {
         self.response = response
         self.verificationResult = verificationResult
+        self.verificationReason = verificationReason
     }
 
     init(
@@ -81,7 +83,8 @@ struct VerifiedHTTPResponse<Body: HTTPResponseBody>: HTTPResponseType {
         responseHeaders: HTTPClient.ResponseHeaders,
         body: Body,
         requestDate: Date? = nil,
-        verificationResult: VerificationResult
+        verificationResult: VerificationResult,
+        verificationReason: VerificationReason?
     ) {
         self.init(
             response: .init(
@@ -90,7 +93,8 @@ struct VerifiedHTTPResponse<Body: HTTPResponseBody>: HTTPResponseType {
                 body: body,
                 requestDate: requestDate
             ),
-            verificationResult: verificationResult
+            verificationResult: verificationResult,
+            verificationReason: verificationReason
         )
     }
 
@@ -180,10 +184,11 @@ extension HTTPResponse {
                      requestDate: self.requestDate)
     }
 
-    func verified(with verificationResult: VerificationResult) -> VerifiedHTTPResponse<Body> {
+    func verified(with verificationResult: VerificationResult, verificationReason: VerificationReason?) -> VerifiedHTTPResponse<Body> {
         return .init(
             response: self,
-            verificationResult: verificationResult
+            verificationResult: verificationResult,
+            verificationReason: verificationReason
         )
     }
 
@@ -226,7 +231,8 @@ extension VerifiedHTTPResponse {
     func mapBody<NewBody>(_ mapping: (Body) throws -> NewBody) rethrows -> VerifiedHTTPResponse<NewBody> {
         return .init(
             response: try self.response.mapBody(mapping),
-            verificationResult: self.verificationResult
+            verificationResult: self.verificationResult,
+            verificationReason: self.verificationReason
         )
     }
 

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -50,7 +50,10 @@ class CustomerInfoResponseHandler {
                     _ = response.body.errorResponse.asBackendError(with: response.httpStatusCode)
                 }
 
-                return response.body.customerInfo.copy(with: response.verificationResult)
+                return response.body.customerInfo.copy(
+                    with: response.verificationResult,
+                    entitlementVerificationReason: response.verificationReason
+                )
             }
             .mapError(BackendError.networkError)
 

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -86,7 +86,10 @@ private extension LogInOperation {
         let result: Result<(info: CustomerInfo, created: Bool), BackendError> = result
             .map { response in
                 (
-                    response.body.copy(with: response.verificationResult),
+                    response.body.copy(
+                        with: response.verificationResult,
+                        entitlementVerificationReason: response.verificationReason
+                    ),
                     created: response.httpStatusCode == .createdSuccess
                 )
             }

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -47,6 +47,7 @@ extension CustomerInfo {
         self.init(
             response: content,
             entitlementVerification: Self.verification,
+            entitlementVerificationReason: Self.verificationReason,
             sandboxEnvironmentDetector: sandboxEnvironmentDetector
         )
     }
@@ -94,6 +95,7 @@ private extension CustomerInfo {
 
     /// Purchases are verified with StoreKit 2.
     private static let verification: VerificationResult = .verifiedOnDevice
+    private static let verificationReason: VerificationReason? = nil
 
 }
 

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -40,8 +40,11 @@ import Foundation
     /// - ``VerificationResult``
     @objc public var verification: VerificationResult { return self._verification }
     
-    @objc public var verificationReason: VerificationReason? {
-        self._verificationReason
+    @objc public var verificationReason: VerificationReasonContainer? {
+        if let reason = self._verificationReason {
+            return VerificationReasonContainer(reason)
+        }
+        return nil
     }
 
     public override var description: String {
@@ -64,10 +67,12 @@ import Foundation
 
     init(
         entitlements: [String: EntitlementInfo],
-        verification: VerificationResult
+        verification: VerificationResult,
+        verificationReason: VerificationReason?
     ) {
         self.all = entitlements
         self._verification = verification
+        self._verificationReason = verificationReason
     }
 
     private func isEqual(to other: EntitlementInfos?) -> Bool {
@@ -126,7 +131,8 @@ extension EntitlementInfos {
         purchases: [String: CustomerInfoResponse.Subscription],
         requestDate: Date,
         sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
-        verification: VerificationResult
+        verification: VerificationResult,
+        verificationReason: VerificationReason?
     ) {
         let allEntitlements: [String: EntitlementInfo] = .init(
             uniqueKeysWithValues: entitlements.compactMap { identifier, entitlement in
@@ -146,7 +152,7 @@ extension EntitlementInfos {
             }
         )
 
-        self.init(entitlements: allEntitlements, verification: verification)
+        self.init(entitlements: allEntitlements, verification: verification, verificationReason: verificationReason)
     }
 
 }

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -39,6 +39,10 @@ import Foundation
     /// ### Related Symbols
     /// - ``VerificationResult``
     @objc public var verification: VerificationResult { return self._verification }
+    
+    @objc public var verificationReason: VerificationReason? {
+        self._verificationReason
+    }
 
     public override var description: String {
         return "<\(NSStringFromClass(Self.self)): " +
@@ -80,6 +84,7 @@ import Foundation
 
     private let _verification: VerificationResult
 
+    private let _verificationReason: VerificationReason?
 }
 
 public extension EntitlementInfos {

--- a/Sources/Security/FakeSigning.swift
+++ b/Sources/Security/FakeSigning.swift
@@ -23,8 +23,8 @@ final class FakeSigning: SigningType {
         signature: String,
         with parameters: Signing.SignatureParameters,
         publicKey: Signing.PublicKey
-    ) -> Bool {
-        return false
+    ) -> VerificationReason? {
+        return .signatureFailedVerification
     }
 
     static let `default`: FakeSigning = .init()

--- a/Sources/Security/VerificationReason.swift
+++ b/Sources/Security/VerificationReason.swift
@@ -14,8 +14,6 @@ public enum VerificationReason {
     case requestDateMissingFromHeaders(String)
 }
 
-// Clase wrapper para Objective-C
-@objc(RCVerificationReason)
 public class VerificationReasonContainer: NSObject, @unchecked Sendable {
     
     @objc public enum Reason: Int, Sendable {

--- a/Sources/Security/VerificationReason.swift
+++ b/Sources/Security/VerificationReason.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public enum VerificationReason {
+    case invalidPublicKey(String)
+    case signatureNotBase64(String)
+    case signatureInvalidSize(Data)
+    case signatureFailedVerification(String)
+    case intermediateKeyFailedVerification(signature: Data)
+    case intermediateKeyFailedCreation(Error)
+    case intermediateKeyExpired(Date, Data)
+    case intermediateKeyInvalid(Data)
+    case intermediateKeyCreating(expiration: Date, data: Data)
+}
+
+// Clase wrapper para Objective-C
+@objc(RCVerificationReason)
+public class VerificationReasonContainer: NSObject, @unchecked Sendable {
+    
+    @objc public enum Reason: Int, Sendable {
+        case invalidPublicKey = 0
+        case signatureNotBase64 = 1
+        case signatureInvalidSize = 2
+        case signatureFailedVerification = 3
+        case intermediateKeyFailedVerification = 4
+        case intermediateKeyFailedCreation = 5
+        case intermediateKeyExpired = 6
+        case intermediateKeyInvalid = 7
+        case intermediateKeyCreating = 8
+    }
+    
+    @objc public let reasonType: Reason
+    @objc public let details: String
+    
+    public let swiftReason: VerificationReason
+    
+    public init(_ reason: VerificationReason) {
+        self.swiftReason = reason
+        
+        switch reason {
+        case .invalidPublicKey(let value):
+            self.reasonType = .invalidPublicKey
+            self.details = value
+        case .signatureNotBase64(let value):
+            self.reasonType = .signatureNotBase64
+            self.details = value
+        case .signatureInvalidSize(let data):
+            self.reasonType = .signatureInvalidSize
+            self.details = "Size: \(data.count)"
+        case .signatureFailedVerification(let value):
+            self.reasonType = .signatureFailedVerification
+            self.details = value
+        case .intermediateKeyFailedVerification(let signature):
+            self.reasonType = .intermediateKeyFailedVerification
+            self.details = "Signature size: \(signature.count)"
+        case .intermediateKeyFailedCreation(let error):
+            self.reasonType = .intermediateKeyFailedCreation
+            self.details = "Error: \(error.localizedDescription)"
+        case .intermediateKeyExpired(let date, _):
+            self.reasonType = .intermediateKeyExpired
+            self.details = "Expired: \(date)"
+        case .intermediateKeyInvalid(_):
+            self.reasonType = .intermediateKeyInvalid
+            self.details = "Invalid intermediate key"
+        case .intermediateKeyCreating(let expiration, _):
+            self.reasonType = .intermediateKeyCreating
+            self.details = "Expiration: \(expiration)"
+        }
+    }
+}
+
+extension VerificationReason: Sendable {}


### PR DESCRIPTION
[MON-1167](https://goodnotes.atlassian.net/browse/MON-1167)

We want to consume the reason why a signature verification failed from the app. This PR adds support to make it available to the Consumer SDK.

[MON-1167]: https://goodnotes.atlassian.net/browse/MON-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ