### PR TITLE
[iOS] Parsing all paywall ids from CustomerInfoResponse

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -30,6 +30,10 @@ extension CustomerInfoResponse {
     
     struct UIConfig {
         var paywall: String?
+        var paywallWithOtp: String?
+        var paywallPersonalProOnly: String?
+        var paywallProOnly: String?
+        var paywallAiPass: String?
     }
 
     struct Subscriber {

--- a/Sources/Purchasing/CustomerInfoMetadata.swift
+++ b/Sources/Purchasing/CustomerInfoMetadata.swift
@@ -5,17 +5,39 @@ public final class CustomerInfoMetadata: NSObject {
     @objc public let paywallConfig: CustomerInfoPaywallConfig?
 
     init?(from uiConfigMapping: CustomerInfoResponse.UIConfig?) {
-        guard let uiConfigMapping, let paywallId = uiConfigMapping.paywall else { return nil }
-        self.paywallConfig = .init(paywallId: paywallId)
+        guard let uiConfigMapping,
+              let regularId = uiConfigMapping.paywall,
+              let hiddenOtpId = uiConfigMapping.paywallWithOtp,
+              let personalProOnlyId = uiConfigMapping.paywallPersonalProOnly,
+              let proOnlyId = uiConfigMapping.paywallProOnly,
+              let aiPassId = uiConfigMapping.paywallAiPass
+        else {
+            return nil
+        }
+        self.paywallConfig = .init(
+            regularId: regularId,
+            hiddenOtpId: hiddenOtpId,
+            personalProOnlyId: personalProOnlyId,
+            proOnlyId: proOnlyId,
+            aiPassId: aiPassId
+        )
     }
 }
 
 @objc(RCCustomerInfoPaywallConfig)
 public final class CustomerInfoPaywallConfig: NSObject {
-    @objc public let paywallId: String
+    @objc public let regularId: String
+    @objc public let hiddenOtpId: String
+    @objc public let personalProOnlyId: String
+    @objc public let proOnlyId: String
+    @objc public let aiPassId: String
 
-    init(paywallId: String) {
-        self.paywallId = paywallId
+    init(regularId: String, hiddenOtpId: String, personalProOnlyId: String, proOnlyId: String, aiPassId: String) {
+        self.regularId = regularId
+        self.hiddenOtpId = hiddenOtpId
+        self.personalProOnlyId = personalProOnlyId
+        self.proOnlyId = proOnlyId
+        self.aiPassId = aiPassId
     }
 }
 


### PR DESCRIPTION
[MON-1865](https://goodnotes.atlassian.net/browse/MON-1865)

We have up to 5 different paywalls configured remotely. Their IDs are returned in the CustomerInfoResponse. This PR adds support to parse the returned data.

[MON-1865]: https://goodnotes.atlassian.net/browse/MON-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ