### PR TITLE
[MNA-3651] [iOS] Storekit 2 - Add additional transactions and renewal info to v1/receipts API

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -16,6 +16,7 @@ import Foundation
     internal struct Internal: InternalDangerousSettingsType {
 
         let enableReceiptFetchRetry: Bool
+        let sk2AdditionalTransactionDataEnabled: Bool
 
         #if DEBUG
         let forceServerErrors: Bool
@@ -25,12 +26,14 @@ import Foundation
 
         init(
             enableReceiptFetchRetry: Bool = false,
+            sk2AdditionalTransactionDataEnabled: Bool = false,
             forceServerErrors: Bool = false,
             forceSignatureFailures: Bool = false,
             disableHeaderSignatureVerification: Bool = false,
             testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
+            self.sk2AdditionalTransactionDataEnabled = sk2AdditionalTransactionDataEnabled
             self.forceServerErrors = forceServerErrors
             self.forceSignatureFailures = forceSignatureFailures
             self.disableHeaderSignatureVerification = disableHeaderSignatureVerification
@@ -38,9 +41,11 @@ import Foundation
         }
         #else
         init(
-            enableReceiptFetchRetry: Bool = false
+            enableReceiptFetchRetry: Bool = false,
+            sk2AdditionalTransactionDataEnabled: Bool = false
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
+            self.sk2AdditionalTransactionDataEnabled = sk2AdditionalTransactionDataEnabled
         }
 
         #endif
@@ -137,6 +142,10 @@ internal protocol InternalDangerousSettingsType: Sendable {
 
     /// Whether `ReceiptFetcher` can retry fetching receipts.
     var enableReceiptFetchRetry: Bool { get }
+
+    /// Whether to include SK2 `transactions` and `renewal_info` in the `/v1/receipts` request body
+    /// and signature hash. Disabled by default; enable once the backend is ready to consume these fields.
+    var sk2AdditionalTransactionDataEnabled: Bool { get }
 
     #if DEBUG
     /// Whether `HTTPClient` will fake server errors

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -83,6 +83,10 @@ import Foundation
      */
     @objc public let customEntitlementComputation: Bool
 
+    /// When `true`, SK2 `transactions` and `renewal_info` are included in the `/v1/receipts`
+    /// request body and signature hash. Defaults to `false`.
+    public let sk2AdditionalTransactionDataEnabled: Bool
+
     internal let internalSettings: InternalDangerousSettingsType
 
     @objc public override convenience init() {
@@ -122,6 +126,13 @@ import Foundation
         self.init(autoSyncPurchases: false, internalSettings: Internal.default, uiPreviewMode: uiPreviewMode)
     }
 
+    /// Creates a `DangerousSettings` controlling whether SK2 additional transaction data
+    /// (`transactions` and `renewal_info`) is included in the `/v1/receipts` request.
+    public convenience init(sk2AdditionalTransactionDataEnabled: Bool) {
+        self.init(autoSyncPurchases: true,
+                  internalSettings: Internal(sk2AdditionalTransactionDataEnabled: sk2AdditionalTransactionDataEnabled))
+    }
+
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
@@ -131,6 +142,7 @@ import Foundation
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
         self.uiPreviewMode = uiPreviewMode
+        self.sk2AdditionalTransactionDataEnabled = internalSettings.sk2AdditionalTransactionDataEnabled
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -132,12 +132,16 @@ class Backend {
               transactionData: PurchasedTransactionData,
               observerMode: Bool,
               appTransaction: String? = nil,
+              transactions: [String]? = nil,
+              renewalInfo: [String]? = nil,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         self.customer.post(receipt: receipt,
                            productData: productData,
                            transactionData: transactionData,
                            observerMode: observerMode,
                            appTransaction: appTransaction,
+                           transactions: transactions,
+                           renewalInfo: renewalInfo,
                            completion: completion)
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -93,6 +93,8 @@ final class CustomerAPI {
               transactionData: PurchasedTransactionData,
               observerMode: Bool,
               appTransaction: String?,
+              transactions: [String]? = nil,
+              renewalInfo: [String]? = nil,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         var subscriberAttributesToPost: SubscriberAttribute.Dictionary?
 
@@ -114,7 +116,9 @@ final class CustomerAPI {
             receipt: receipt,
             observerMode: observerMode,
             testReceiptIdentifier: self.backendConfig.systemInfo.testReceiptIdentifier,
-            appTransaction: appTransaction
+            appTransaction: appTransaction,
+            transactions: transactions,
+            renewalInfo: renewalInfo
         )
         let factory = PostReceiptDataOperation.createFactory(
             configuration: config,

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -355,11 +355,18 @@ extension PostReceiptDataOperation.AppliedTargetingRule: Codable {
 extension PostReceiptDataOperation.PostData: HTTPRequestBody {
 
     var contentForSignature: [(key: String, value: String?)] {
-        return [
+        var fields: [(key: String, value: String?)] = [
             (Self.CodingKeys.appUserID.stringValue, self.appUserID),
             (Self.CodingKeys.fetchToken.stringValue, self.fetchToken),
             (Self.CodingKeys.appTransaction.stringValue, self.appTransaction)
         ]
+        if self.transactions != nil || self.renewalInfo != nil {
+            fields.append((Self.CodingKeys.transactions.stringValue,
+                           self.transactions.map { $0.joined(separator: ",") }))
+            fields.append((Self.CodingKeys.renewalInfo.stringValue,
+                           self.renewalInfo.map { $0.joined(separator: ",") }))
+        }
+        return fields
     }
 
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -142,6 +142,11 @@ extension PostReceiptDataOperation {
         /// retrieved from StoreKit 2.
         let appTransaction: String?
         let metadata: [String: String]?
+
+        /// All signed StoreKit 2 transaction JWS tokens.
+        let transactions: [String]?
+        /// All signed StoreKit 2 renewal info JWS tokens.
+        let renewalInfo: [String]?
     }
 
     struct Paywall {
@@ -171,7 +176,9 @@ extension PostReceiptDataOperation.PostData {
         receipt: EncodedAppleReceipt,
         observerMode: Bool,
         testReceiptIdentifier: String?,
-        appTransaction: String?
+        appTransaction: String?,
+        transactions: [String]? = nil,
+        renewalInfo: [String]? = nil
     ) {
         self.init(
             appUserID: data.appUserID,
@@ -190,7 +197,9 @@ extension PostReceiptDataOperation.PostData {
             aadAttributionToken: data.aadAttributionToken,
             testReceiptIdentifier: testReceiptIdentifier,
             appTransaction: appTransaction,
-            metadata: data.metadata
+            metadata: data.metadata,
+            transactions: transactions,
+            renewalInfo: renewalInfo
         )
     }
 
@@ -274,6 +283,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case testReceiptIdentifier = "test_receipt_identifier"
         case appTransaction = "app_transaction"
         case metadata
+        case transactions
+        case renewalInfo = "renewal_info"
 
     }
 
@@ -306,6 +317,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
 
         try container.encodeIfPresent(self.aadAttributionToken, forKey: .aadAttributionToken)
         try container.encodeIfPresent(self.testReceiptIdentifier, forKey: .testReceiptIdentifier)
+        try container.encodeIfPresent(self.transactions, forKey: .transactions)
+        try container.encodeIfPresent(self.renewalInfo, forKey: .renewalInfo)
     }
 
     var fetchToken: String? { return self.receipt.serialized() }

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -107,12 +107,23 @@ final class TransactionPoster: TransactionPosterType {
             switch result {
             case .success(let encodedReceipt):
                 self.product(with: productIdentifier) { product in
-                    self.transactionFetcher.appTransactionJWS { appTransaction in
+                    _ = Task<Void, Never> {
+                        let appTransaction = await self.transactionFetcher.appTransactionJWS
+                        var transactions: [String]? = nil
+                        var renewalInfo: [String]? = nil
+                        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+                            async let txs = self.transactionFetcher.allTransactionJWS
+                            async let renewal = self.transactionFetcher.renewalInfoJWS
+                            transactions = await txs
+                            renewalInfo = await renewal
+                        }
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,
                                          receipt: encodedReceipt,
                                          product: product,
                                          appTransaction: appTransaction,
+                                         transactions: transactions,
+                                         renewalInfo: renewalInfo,
                                          completion: completion)
                     }
                 }
@@ -241,6 +252,8 @@ private extension TransactionPoster {
                      receipt: EncodedAppleReceipt,
                      product: StoreProduct?,
                      appTransaction: String?,
+                     transactions: [String]?,
+                     renewalInfo: [String]?,
                      completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         let productData = product.map { ProductRequestData(with: $0, storefront: purchasedTransactionData.storefront) }
 
@@ -248,7 +261,9 @@ private extension TransactionPoster {
                           productData: productData,
                           transactionData: purchasedTransactionData,
                           observerMode: self.observerMode,
-                          appTransaction: appTransaction) { result in
+                          appTransaction: appTransaction,
+                          transactions: transactions,
+                          renewalInfo: renewalInfo) { result in
             self.handleReceiptPost(withTransaction: transaction,
                                    result: result.map { ($0, product) },
                                    subscriberAttributes: purchasedTransactionData.unsyncedAttributes,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -112,10 +112,11 @@ final class TransactionPoster: TransactionPosterType {
                         var transactions: [String]? = nil
                         var renewalInfo: [String]? = nil
                         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-                            async let txs = self.transactionFetcher.allTransactionJWS
-                            async let renewal = self.transactionFetcher.renewalInfoJWS
-                            transactions = await txs
-                            renewalInfo = await renewal
+                            let receipt = await self.transactionFetcher.fetchReceipt(containing: transaction)
+                            transactions = receipt.transactions
+                            renewalInfo = receipt.subscriptionStatusBySubscriptionGroupId.values
+                                .flatMap { $0 }
+                                .map { $0.renewalInfoJWSToken }
                         }
                         self.postReceipt(transaction: transaction,
                                          purchasedTransactionData: data,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -111,7 +111,8 @@ final class TransactionPoster: TransactionPosterType {
                         let appTransaction = await self.transactionFetcher.appTransactionJWS
                         var transactions: [String]? = nil
                         var renewalInfo: [String]? = nil
-                        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+                        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *),
+                           self.systemInfo.dangerousSettings.internalSettings.sk2AdditionalTransactionDataEnabled {
                             let receipt = await self.transactionFetcher.fetchReceipt(containing: transaction)
                             transactions = receipt.transactions
                             renewalInfo = receipt.subscriptionStatusBySubscriptionGroupId.values

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -34,12 +34,6 @@ protocol StoreKit2TransactionFetcherType: Sendable {
     var appTransactionJWS: String? { get async }
 
     func appTransactionJWS(_ completionHandler: @escaping (String?) -> Void)
-    
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var allTransactionJWS: [String] { get async }
-
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var renewalInfoJWS: [String] { get async }
 
 }
 
@@ -107,24 +101,6 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
             originalApplicationVersion: appTransaction?.originalApplicationVersion,
             originalPurchaseDate: appTransaction?.originalPurchaseDate
         )
-    }
-
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var allTransactionJWS: [String] {
-        get async {
-            return await StoreKit.Transaction.all
-                .compactMap { $0.verifiedStoreTransaction }
-                .compactMap(\.jwsRepresentation)
-                .extractValues()
-        }
-    }
-
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var renewalInfoJWS: [String] {
-        get async {
-            let statuses = await subscriptionStatusBySubscriptionGroupId
-            return statuses.values.flatMap { $0 }.map { $0.renewalInfo.jwsRepresentation }
-        }
     }
 
     /// A computed property that retrieves the JWS (JSON Web Signature) representation

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -34,6 +34,12 @@ protocol StoreKit2TransactionFetcherType: Sendable {
     var appTransactionJWS: String? { get async }
 
     func appTransactionJWS(_ completionHandler: @escaping (String?) -> Void)
+    
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var allTransactionJWS: [String] { get async }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var renewalInfoJWS: [String] { get async }
 
 }
 
@@ -103,7 +109,25 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         )
     }
 
-    /// A computed property that retrieves the JWS (JSON Web Signature) representation 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var allTransactionJWS: [String] {
+        get async {
+            return await StoreKit.Transaction.all
+                .compactMap { $0.verifiedStoreTransaction }
+                .compactMap(\.jwsRepresentation)
+                .extractValues()
+        }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var renewalInfoJWS: [String] {
+        get async {
+            let statuses = await subscriptionStatusBySubscriptionGroupId
+            return statuses.values.flatMap { $0 }.map { $0.renewalInfo.jwsRepresentation }
+        }
+    }
+
+    /// A computed property that retrieves the JWS (JSON Web Signature) representation
     /// of the app transaction asynchronously.
     ///
     /// If the OS does not support AppTransaction (available in iOS16+), it returns `nil`.

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -60,7 +60,7 @@ class BaseBackendIntegrationTests: TestCase {
     class var storeKitVersion: StoreKitVersion { return .default }
     class var observerMode: Bool { return false }
     class var responseVerificationMode: Signing.ResponseVerificationMode {
-        return .enforced(Signing.loadPublicKey())
+        return .enforced(Signing.loadPublicKey(), Signing.loadCustomPublicKey())
     }
     var enableReceiptFetchRetry: Bool = true
 
@@ -242,6 +242,7 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     var forceSignatureFailures: Bool { return false }
     var disableHeaderSignatureVerification: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
+    var sk2AdditionalTransactionDataEnabled: Bool { return false }
 
     final func serverDown() { self.serverIsDown = true }
     final func serverUp() { self.serverIsDown = false }

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -50,7 +50,7 @@ class DisabledSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
 class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificationIntegrationTests {
 
     override class var responseVerificationMode: Signing.ResponseVerificationMode {
-        return .informational(Signing.loadPublicKey())
+        return .informational(Signing.loadPublicKey(), Signing.loadCustomPublicKey())
     }
 
     func testCustomerInfoWithValidSignature() async throws {
@@ -172,7 +172,7 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
 class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIntegrationTests {
 
     override class var responseVerificationMode: Signing.ResponseVerificationMode {
-        return .enforced(Signing.loadPublicKey())
+        return .enforced(Signing.loadPublicKey(), Signing.loadCustomPublicKey())
     }
 
     func testCustomerInfoWithValidSignature() async throws {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -13,6 +13,8 @@ class MockBackend: Backend {
                                        transactionData: PurchasedTransactionData,
                                        observerMode: Bool,
                                        appTransaction: String?,
+                                       transactions: [String]?,
+                                       renewalInfo: [String]?,
                                        completion: CustomerAPI.CustomerInfoResponseHandler?)
 
     var invokedPostReceiptData = false
@@ -51,6 +53,8 @@ class MockBackend: Backend {
                        transactionData: PurchasedTransactionData,
                        observerMode: Bool,
                        appTransaction: String? = nil,
+                       transactions: [String]? = nil,
+                       renewalInfo: [String]? = nil,
                        completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedPostReceiptData = true
         invokedPostReceiptDataCount += 1
@@ -59,12 +63,16 @@ class MockBackend: Backend {
                                             transactionData,
                                             observerMode,
                                             appTransaction,
+                                            transactions,
+                                            renewalInfo,
                                             completion)
         invokedPostReceiptDataParametersList.append((receipt,
                                                      productData,
                                                      transactionData,
                                                      observerMode,
                                                      appTransaction,
+                                                     transactions,
+                                                     renewalInfo,
                                                      completion))
 
         self.onPostReceipt?()

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -22,6 +22,8 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     private let _stubbedHasPendingConsumablePurchase: Atomic<Bool> = false
     private let _stubbedReceipt: Atomic<StoreKit2Receipt?> = .init(nil)
     private let _stubbedAppTransactionJWS: Atomic<String?> = .init(nil)
+    private let _stubbedAllTransactionJWS: Atomic<[String]> = .init([])
+    private let _stubbedRenewalInfoJWS: Atomic<[String]> = .init([])
 
     var stubbedUnfinishedTransactions: [StoreTransaction] {
         get { return self._stubbedUnfinishedTransactions.value }
@@ -46,6 +48,16 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     var stubbedAppTransactionJWS: String? {
         get { return self._stubbedAppTransactionJWS.value }
         set { self._stubbedAppTransactionJWS.value = newValue }
+    }
+
+    var stubbedAllTransactionJWS: [String] {
+        get { return self._stubbedAllTransactionJWS.value }
+        set { self._stubbedAllTransactionJWS.value = newValue }
+    }
+
+    var stubbedRenewalInfoJWS: [String] {
+        get { return self._stubbedRenewalInfoJWS.value }
+        set { self._stubbedRenewalInfoJWS.value = newValue }
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -82,6 +94,16 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
 
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         completion(self.stubbedAppTransactionJWS)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var allTransactionJWS: [String] {
+        get async { self.stubbedAllTransactionJWS }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var renewalInfoJWS: [String] {
+        get async { self.stubbedRenewalInfoJWS }
     }
 
     // MARK: -

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -22,9 +22,6 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
     private let _stubbedHasPendingConsumablePurchase: Atomic<Bool> = false
     private let _stubbedReceipt: Atomic<StoreKit2Receipt?> = .init(nil)
     private let _stubbedAppTransactionJWS: Atomic<String?> = .init(nil)
-    private let _stubbedAllTransactionJWS: Atomic<[String]> = .init([])
-    private let _stubbedRenewalInfoJWS: Atomic<[String]> = .init([])
-
     var stubbedUnfinishedTransactions: [StoreTransaction] {
         get { return self._stubbedUnfinishedTransactions.value }
         set { self._stubbedUnfinishedTransactions.value = newValue }
@@ -50,16 +47,6 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         set { self._stubbedAppTransactionJWS.value = newValue }
     }
 
-    var stubbedAllTransactionJWS: [String] {
-        get { return self._stubbedAllTransactionJWS.value }
-        set { self._stubbedAllTransactionJWS.value = newValue }
-    }
-
-    var stubbedRenewalInfoJWS: [String] {
-        get { return self._stubbedRenewalInfoJWS.value }
-        set { self._stubbedRenewalInfoJWS.value = newValue }
-    }
-
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var unfinishedVerifiedTransactions: [StoreTransaction] {
         get async {
@@ -69,7 +56,14 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func fetchReceipt(containing transaction: StoreTransactionType) async -> StoreKit2Receipt {
-        return self.stubbedReceipt!
+        return self.stubbedReceipt ?? StoreKit2Receipt(
+            environment: .production,
+            subscriptionStatusBySubscriptionGroupId: [:],
+            transactions: [],
+            bundleId: "",
+            originalApplicationVersion: nil,
+            originalPurchaseDate: nil
+        )
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -94,16 +88,6 @@ final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
 
     func appTransactionJWS(_ completion: @escaping (String?) -> Void) {
         completion(self.stubbedAppTransactionJWS)
-    }
-
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var allTransactionJWS: [String] {
-        get async { self.stubbedAllTransactionJWS }
-    }
-
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    var renewalInfoJWS: [String] {
-        get async { self.stubbedRenewalInfoJWS }
     }
 
     // MARK: -

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -36,6 +36,25 @@ class MockSystemInfo: SystemInfo {
                   clock: clock)
     }
 
+    convenience init(finishTransactions: Bool,
+                     storeKitVersion: StoreKitVersion = .default,
+                     sk2AdditionalTransactionDataEnabled: Bool,
+                     clock: ClockType = TestClock()) {
+        let internalSettings = DangerousSettings.Internal(
+            sk2AdditionalTransactionDataEnabled: sk2AdditionalTransactionDataEnabled
+        )
+        let dangerousSettings = DangerousSettings(
+            autoSyncPurchases: true,
+            customEntitlementComputation: false,
+            internalSettings: internalSettings
+        )
+        self.init(platformInfo: nil,
+                  finishTransactions: finishTransactions,
+                  storeKitVersion: storeKitVersion,
+                  dangerousSettings: dangerousSettings,
+                  clock: clock)
+    }
+
     override func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {
         completion(stubbedIsApplicationBackgrounded ?? false)
     }

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -157,6 +157,93 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         expect(self.httpClient.calls).to(haveCount(1))
     }
 
+    func testPostsReceiptDataWithTransactionsAndRenewalInfoCorrectly() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        let path: HTTPRequest.Path = .postReceiptData
+
+        httpClient.mock(
+            requestPath: path,
+            response: .init(statusCode: .success, response: Self.validCustomerResponse)
+        )
+
+        let transactions = ["tx-jws-1", "tx-jws-2"]
+        let renewalInfo = ["renewal-jws-1"]
+
+        waitUntil { completed in
+            self.backend.post(receipt: Self.receipt,
+                              productData: nil,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingContext: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: false, initiationSource: .purchase)
+                              ),
+                              observerMode: false,
+                              appTransaction: nil,
+                              transactions: transactions,
+                              renewalInfo: renewalInfo,
+                              completion: { _ in
+                completed()
+            })
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
+    func testPostReceiptDataEncodesTransactionsAndRenewalInfoInBody() throws {
+        let postData = PostReceiptDataOperation.PostData(
+            transactionData: .init(
+                appUserID: "user",
+                presentedOfferingContext: nil,
+                unsyncedAttributes: nil,
+                storefront: nil,
+                source: .init(isRestore: false, initiationSource: .purchase)
+            ),
+            productData: nil,
+            receipt: Self.receipt,
+            observerMode: false,
+            testReceiptIdentifier: nil,
+            appTransaction: nil,
+            transactions: ["tx-jws-1", "tx-jws-2"],
+            renewalInfo: ["renewal-jws-1"]
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(postData)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        expect(json["transactions"] as? [String]) == ["tx-jws-1", "tx-jws-2"]
+        expect(json["renewal_info"] as? [String]) == ["renewal-jws-1"]
+    }
+
+    func testPostReceiptDataOmitsTransactionsAndRenewalInfoWhenNil() throws {
+        let postData = PostReceiptDataOperation.PostData(
+            transactionData: .init(
+                appUserID: "user",
+                presentedOfferingContext: nil,
+                unsyncedAttributes: nil,
+                storefront: nil,
+                source: .init(isRestore: false, initiationSource: .purchase)
+            ),
+            productData: nil,
+            receipt: Self.receipt,
+            observerMode: false,
+            testReceiptIdentifier: nil,
+            appTransaction: nil,
+            transactions: nil,
+            renewalInfo: nil
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(postData)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        expect(json["transactions"]).to(beNil())
+        expect(json["renewal_info"]).to(beNil())
+    }
+
     func testPostsReceiptDataWithTestReceiptIdentifier() throws {
         let identifier = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-C2C35AE34D09")).uuidString
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -466,6 +466,8 @@ extension BasePurchasesTests {
                            transactionData: PurchasedTransactionData,
                            observerMode: Bool,
                            appTransaction: String? = nil,
+                           transactions: [String]? = nil,
+                           renewalInfo: [String]? = nil,
                            completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.postReceiptDataCalled = true
             self.postedReceiptData = receipt

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -137,9 +137,17 @@ class TransactionPosterTests: TestCase {
         self.mockTransaction = MockStoreTransaction(jwsRepresentation: jwsRepresentation)
 
         let allTransactions = ["tx-jws-1", "tx-jws-2"]
-        let renewalInfo = ["renewal-jws-1"]
-        self.transactionFetcher.stubbedAllTransactionJWS = allTransactions
-        self.transactionFetcher.stubbedRenewalInfoJWS = renewalInfo
+        let renewalJWS = "renewal-jws-1"
+        self.transactionFetcher.stubbedReceipt = StoreKit2Receipt(
+            environment: .production,
+            subscriptionStatusBySubscriptionGroupId: [
+                "group1": [.init(state: .subscribed, renewalInfoJWSToken: renewalJWS, transactionJWSToken: "tx-jws-1")]
+            ],
+            transactions: allTransactions,
+            bundleId: "com.example.app",
+            originalApplicationVersion: nil,
+            originalPurchaseDate: nil
+        )
 
         let product = MockSK1Product(mockProductIdentifier: "product")
         let transactionData = PurchasedTransactionData(
@@ -155,7 +163,7 @@ class TransactionPosterTests: TestCase {
         expect(result).to(beSuccess())
 
         expect(self.backend.invokedPostReceiptDataParameters?.transactions) == allTransactions
-        expect(self.backend.invokedPostReceiptDataParameters?.renewalInfo) == renewalInfo
+        expect(self.backend.invokedPostReceiptDataParameters?.renewalInfo) == [renewalJWS]
     }
 
     func testHandlePurchasedTransactionSendsSK2Receipt() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -129,6 +129,35 @@ class TransactionPosterTests: TestCase {
         expect(self.mockTransaction.finishInvoked) == true
     }
 
+    func testHandlePurchasedTransactionSendsAllTransactionsAndRenewalInfo() throws {
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        self.setUp(observerMode: false, storeKitVersion: .storeKit2)
+        let jwsRepresentation = UUID().uuidString
+        self.mockTransaction = MockStoreTransaction(jwsRepresentation: jwsRepresentation)
+
+        let allTransactions = ["tx-jws-1", "tx-jws-2"]
+        let renewalInfo = ["renewal-jws-1"]
+        self.transactionFetcher.stubbedAllTransactionJWS = allTransactions
+        self.transactionFetcher.stubbedRenewalInfoJWS = renewalInfo
+
+        let product = MockSK1Product(mockProductIdentifier: "product")
+        let transactionData = PurchasedTransactionData(
+            appUserID: "user",
+            source: .init(isRestore: false, initiationSource: .purchase)
+        )
+
+        self.receiptFetcher.shouldReturnReceipt = false
+        self.productsManager.stubbedProductsCompletionResult = .success([StoreProduct(sk1Product: product)])
+        self.backend.stubbedPostReceiptResult = .success(Self.mockCustomerInfo)
+
+        let result = try self.handleTransaction(transactionData)
+        expect(result).to(beSuccess())
+
+        expect(self.backend.invokedPostReceiptDataParameters?.transactions) == allTransactions
+        expect(self.backend.invokedPostReceiptDataParameters?.renewalInfo) == renewalInfo
+    }
+
     func testHandlePurchasedTransactionSendsSK2Receipt() throws {
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -132,7 +132,7 @@ class TransactionPosterTests: TestCase {
     func testHandlePurchasedTransactionSendsAllTransactionsAndRenewalInfo() throws {
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
 
-        self.setUp(observerMode: false, storeKitVersion: .storeKit2)
+        self.setUp(observerMode: false, storeKitVersion: .storeKit2, sk2AdditionalTransactionDataEnabled: true)
         let jwsRepresentation = UUID().uuidString
         self.mockTransaction = MockStoreTransaction(jwsRepresentation: jwsRepresentation)
 
@@ -393,9 +393,13 @@ class TransactionPosterTests: TestCase {
 
 private extension TransactionPosterTests {
 
-    func setUp(observerMode: Bool, storeKitVersion: StoreKitVersion = .default) {
+    func setUp(observerMode: Bool,
+               storeKitVersion: StoreKitVersion = .default,
+               sk2AdditionalTransactionDataEnabled: Bool = false) {
         self.operationDispatcher = .init()
-        self.systemInfo = .init(finishTransactions: !observerMode, storeKitVersion: storeKitVersion)
+        self.systemInfo = .init(finishTransactions: !observerMode,
+                                storeKitVersion: storeKitVersion,
+                                sk2AdditionalTransactionDataEnabled: sk2AdditionalTransactionDataEnabled)
         self.productsManager = .init(diagnosticsTracker: nil, systemInfo: self.systemInfo, requestTimeout: 0)
         self.receiptFetcher = .init(requestFetcher: .init(operationDispatcher: self.operationDispatcher),
                                     systemInfo: self.systemInfo)


### PR DESCRIPTION
…ipts API

<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? --> 

Storekit 2 - Add additional transactions and renewal info to v1/receipts API

<!-- Please link to issues following this format: Resolves #999999 --> 
[MNA-3651](https://goodnotes.atlassian.net/browse/MNA-3651)

### Description
<!-- Describe your changes in detail -->
Extends our purchases-ios-spm fork to augment the existing `/v1/receipts `proxy call with two additional fields:

transactions — JWS tokens for all verified transactions from StoreKit.Transaction.all
renewal_info — JWS renewal info tokens fetched via Product.SubscriptionInfo.Status for all subscription groups

<!-- Please describe in detail how you tested your changes -->
Unit tests added in the fork:

`TransactionPosterTests` — stubs the fetcher with known JWS arrays and asserts they reach `MockBackend`

`BackendPostReceiptDataTests` — verifies the values pass through the Backend → CustomerAPI layer, that they serialize correctly as transactions/renewal_info in the JSON body, and that both keys are omitted entirely when nil

[MNA-3651]: https://goodnotes.atlassian.net/browse/MNA-3651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ