### PR TITLE
[iOS] Add subscription period fields

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -249,7 +249,9 @@ public typealias ProductIdentifier = String
                 price: subscriptionData.price.map { ProductPaidPrice(currency: $0.currency, amount: $0.amount) },
                 planKey: subscriptionData.planKey,
                 pendingProductId: subscriptionData.pendingProductId,
-                pendingProductPlanKey: subscriptionData.pendingProductPlanKey
+                pendingProductPlanKey: subscriptionData.pendingProductPlanKey,
+                subscriptionPeriod: subscriptionData.subscriptionPeriod,
+                pendingSubscriptionPeriod: subscriptionData.pendingSubscriptionPeriod
             ))
         })
     }

--- a/Sources/Identity/SubscriptionInfo.swift
+++ b/Sources/Identity/SubscriptionInfo.swift
@@ -90,6 +90,12 @@ import Foundation
     /// For showing the tier name of the pending product
     @objc public let pendingProductPlanKey: String?
 
+    /// Subscription billing period in ISO-8601 duration format, for example "P1M" or "P1Y".
+    @objc public let subscriptionPeriod: String?
+
+    /// Pending subscription billing period in ISO-8601 duration format, for example "P1M" or "P1Y".
+    @objc public let pendingSubscriptionPeriod: String?
+
     init(productIdentifier: String,
          purchaseDate: Date,
          originalPurchaseDate: Date?,
@@ -107,7 +113,9 @@ import Foundation
          price: ProductPaidPrice?,
          planKey: String?,
          pendingProductId: String?,
-         pendingProductPlanKey: String?) {
+         pendingProductPlanKey: String?,
+         subscriptionPeriod: String?,
+         pendingSubscriptionPeriod: String?) {
         self.productIdentifier = productIdentifier
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
@@ -130,6 +138,8 @@ import Foundation
         self.planKey = planKey
         self.pendingProductId = pendingProductId
         self.pendingProductPlanKey = pendingProductPlanKey
+        self.subscriptionPeriod = subscriptionPeriod
+        self.pendingSubscriptionPeriod = pendingSubscriptionPeriod
 
         super.init()
     }
@@ -154,6 +164,8 @@ import Foundation
             planKey: \(String(describing: planKey)),
             pendingProductId: \(String(describing: pendingProductId))
             pendingProductPlanKey: \(String(describing: pendingProductPlanKey))
+            subscriptionPeriod: \(String(describing: subscriptionPeriod))
+            pendingSubscriptionPeriod: \(String(describing: pendingSubscriptionPeriod))
         }
         """
     }

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -80,6 +80,8 @@ extension CustomerInfoResponse {
         var planKey: String?
         var pendingProductId: String?
         var pendingProductPlanKey: String?
+        var subscriptionPeriod: String?
+        var pendingSubscriptionPeriod: String?
     }
 
     struct PurchasePaidPrice {
@@ -241,7 +243,9 @@ extension CustomerInfoResponse.Subscription {
         unsubscribeDetectedAt: Date? = nil,
         billingIssuesDetectedAt: Date? = nil,
         ownershipType: PurchaseOwnershipType = .defaultValue,
-        storeTransactionId: String? = nil
+        storeTransactionId: String? = nil,
+        subscriptionPeriod: String? = nil,
+        pendingSubscriptionPeriod: String? = nil
     ) {
         self.periodType = periodType
         self.purchaseDate = purchaseDate
@@ -253,6 +257,8 @@ extension CustomerInfoResponse.Subscription {
         self.billingIssuesDetectedAt = billingIssuesDetectedAt
         self.ownershipType = ownershipType
         self.storeTransactionId = storeTransactionId
+        self.subscriptionPeriod = subscriptionPeriod
+        self.pendingSubscriptionPeriod = pendingSubscriptionPeriod
     }
 
     var asTransaction: CustomerInfoResponse.Transaction {

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -195,6 +195,12 @@ extension PeriodType: DefaultValueProvider {
 
     /// For showing the tier name of the pending product
     @objc public var pendingProductPlanKey: String? { self.contents.pendingProductPlanKey }
+
+    /// Subscription billing period in ISO-8601 duration format, for example "P1M" or "P1Y".
+    @objc public var subscriptionPeriod: String? { self.contents.subscriptionPeriod }
+
+    /// Pending subscription billing period in ISO-8601 duration format, for example "P1M" or "P1Y".
+    @objc public var pendingSubscriptionPeriod: String? { self.contents.pendingSubscriptionPeriod }
     
     // Docs inherited from protocol
     // swiftlint:disable:next missing_docs
@@ -222,7 +228,9 @@ extension PeriodType: DefaultValueProvider {
             verification=\(self.contents.verification),
             planKey=\(self.contents.planKey ?? "null"),
             pendingProductId=\(String(describing: self.contents.pendingProductId)),
-            pendingProductPlanKey=\(String(describing: self.contents.pendingProductPlanKey))
+            pendingProductPlanKey=\(String(describing: self.contents.pendingProductPlanKey)),
+            subscriptionPeriod=\(String(describing: self.contents.subscriptionPeriod)),
+            pendingSubscriptionPeriod=\(String(describing: self.contents.pendingSubscriptionPeriod))
             >
             """
     }
@@ -275,7 +283,9 @@ extension PeriodType: DefaultValueProvider {
             verification: verification,
             planKey: subscription.planKey ?? entitlement.planKey,
             pendingProductId: subscription.pendingProductId,
-            pendingProductPlanKey: subscription.pendingProductPlanKey
+            pendingProductPlanKey: subscription.pendingProductPlanKey,
+            subscriptionPeriod: subscription.subscriptionPeriod,
+            pendingSubscriptionPeriod: subscription.pendingSubscriptionPeriod
         )
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
 
@@ -365,6 +375,8 @@ private extension EntitlementInfo {
         let planKey: String?
         let pendingProductId: String?
         let pendingProductPlanKey: String?
+        let subscriptionPeriod: String?
+        let pendingSubscriptionPeriod: String?
 
     }
 


### PR DESCRIPTION
[B2CARR-198](https://goodnotes.atlassian.net/browse/B2CARR-198)

### Motivation
Goodnotes needs to identify the current subscription billing period and pending billing period from the subscriber response without reading raw response dictionaries. These fields are needed to detect monthly subscriptions and annual-to-monthly downgrades from the typed RevenueCat models.

### Description

- Adds `subscriptionPeriod` and `pendingSubscriptionPeriod` to `CustomerInfoResponse.Subscription`.
- Exposes both fields from `SubscriptionInfo` for entries in `subscriptionsByProductIdentifier`.
- Exposes both fields from `EntitlementInfo`, backed by the matching subscription response for the entitlement product.
- Includes both values in debug descriptions to make subscriber period state easier to inspect.


[B2CARR-198]: https://goodnotes.atlassian.net/browse/B2CARR-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ