### PR TITLE
[MNA-3854] Add RevenueCat proxy authentication headers

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -36,6 +36,7 @@ class Backend {
         attributionFetcher: AttributionFetcher,
         offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
         diagnosticsTracker: DiagnosticsTrackerType?,
+        proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider? = nil,
         dateProvider: DateProvider = DateProvider()
     ) {
         let httpClient = HTTPClient(apiKey: apiKey,
@@ -44,6 +45,7 @@ class Backend {
                                     jwtManager: jwtManager,
                                     signing: Signing(apiKey: apiKey, clock: systemInfo.clock),
                                     diagnosticsTracker: diagnosticsTracker,
+                                    proxyAuthenticationHeadersProvider: proxyAuthenticationHeadersProvider,
                                     requestTimeout: httpClientTimeout,
                                     operationDispatcher: OperationDispatcher.default)
         let config = BackendConfiguration(httpClient: httpClient,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -33,6 +33,7 @@ class HTTPClient {
     private let dnsChecker: DNSCheckerType.Type
     private let signing: SigningType
     private let diagnosticsTracker: DiagnosticsTrackerType?
+    private let proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider?
     private let dateProvider: DateProvider
     private let retriableStatusCodes: Set<HTTPStatusCode>
     private let operationDispatcher: OperationDispatcher
@@ -49,6 +50,7 @@ class HTTPClient {
          jwtManager: JWTManager,
          signing: SigningType,
          diagnosticsTracker: DiagnosticsTrackerType?,
+         proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider? = nil,
          dnsChecker: DNSCheckerType.Type = DNSChecker.self,
          retriableStatusCodes: Set<HTTPStatusCode> = Set([.tooManyRequests]),
          requestTimeout: TimeInterval = Configuration.networkTimeoutDefault,
@@ -68,6 +70,7 @@ class HTTPClient {
         self.jwtManager = jwtManager
         self.signing = signing
         self.diagnosticsTracker = diagnosticsTracker
+        self.proxyAuthenticationHeadersProvider = proxyAuthenticationHeadersProvider
         self.dnsChecker = dnsChecker
         self.retriableStatusCodes = retriableStatusCodes
         self.timeout = requestTimeout
@@ -564,19 +567,23 @@ private extension HTTPClient {
     }
 
     private func headers(for request: Request, urlRequest: URLRequest) -> HTTPClient.RequestHeaders {
+        var headers = request.headers
+
         if request.httpRequest.path.shouldSendEtag {
             let eTagHeader = self.eTagManager.eTagHeader(
                 for: urlRequest,
                 withSignatureVerification: request.verificationMode.isEnabled,
                 refreshETag: request.retried
             )
-            return request.headers
-                .merging(eTagHeader)
-                .merging(jwtManager.jwtHeader())
-        } else {
-            return request.headers
-                .merging(jwtManager.jwtHeader())
+            headers.merge(eTagHeader)
         }
+
+        if SystemInfo.proxyURL != nil {
+            headers.mergeAdditionalHTTPHeaders(proxyAuthenticationHeadersProvider?() ?? [:])
+        }
+
+        headers.mergeAdditionalHTTPHeaders(jwtManager.jwtHeader())
+        return headers
     }
 
     private func signing(for request: HTTPRequest) -> SigningType {
@@ -625,6 +632,45 @@ private extension HTTPClient {
             }
         }
     }
+}
+
+private extension Dictionary where Key == String, Value == String {
+
+    private static var cookieHeaderField: String { "Cookie" }
+
+    mutating func mergeAdditionalHTTPHeaders(_ additionalHeaders: [String: String]) {
+        for (header, value) in additionalHeaders where !value.isEmpty {
+            if header.isCookieHeader {
+                appendCookieHeader(value)
+            } else if key(matchingHeader: header) == nil {
+                self[header] = value
+            }
+        }
+    }
+
+    private mutating func appendCookieHeader(_ value: String) {
+        guard let existingKey = key(matchingHeader: Self.cookieHeaderField),
+              let existingValue = self[existingKey],
+              !existingValue.isEmpty else {
+            self[Self.cookieHeaderField] = value
+            return
+        }
+
+        self[existingKey] = "\(existingValue); \(value)"
+    }
+
+    private func key(matchingHeader header: String) -> String? {
+        return keys.first { $0.caseInsensitiveCompare(header) == .orderedSame }
+    }
+
+}
+
+private extension String {
+
+    var isCookieHeader: Bool {
+        return caseInsensitiveCompare("Cookie") == .orderedSame
+    }
+
 }
 
 // MARK: - Request Retry Logic

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -522,13 +522,23 @@ private extension HTTPClient {
     }
 
     func start(request: Request) {
-        let urlRequest = self.convert(request: request)
+        Task {
+            await self.startAsync(request: request)
+        }
+    }
+
+    private func startAsync(request: Request) async {
+        let urlRequest: URLRequest?
+
+        do {
+            urlRequest = try await self.convert(request: request)
+        } catch {
+            self.fail(request: request, with: .networkError(error))
+            return
+        }
 
         guard let urlRequest = urlRequest else {
-            let error: NetworkError = .unableToCreateRequest(request.httpRequest.path)
-
-            Logger.error(error.description)
-            request.completionHandler?(.failure(error))
+            self.fail(request: request, with: .unableToCreateRequest(request.httpRequest.path))
             return
         }
 
@@ -548,13 +558,13 @@ private extension HTTPClient {
         task.resume()
     }
 
-    func convert(request: Request) -> URLRequest? {
+    func convert(request: Request) async throws -> URLRequest? {
         guard let requestURL = request.httpRequest.path.url(proxyURL: SystemInfo.proxyURL) else {
             return nil
         }
         var urlRequest = URLRequest(url: requestURL)
         urlRequest.httpMethod = request.method.httpMethod
-        urlRequest.allHTTPHeaderFields = self.headers(for: request, urlRequest: urlRequest)
+        urlRequest.allHTTPHeaderFields = try await self.headers(for: request, urlRequest: urlRequest)
 
         do {
             urlRequest.httpBody = try request.httpRequest.requestBody?.jsonEncodedData
@@ -566,7 +576,7 @@ private extension HTTPClient {
         return urlRequest
     }
 
-    private func headers(for request: Request, urlRequest: URLRequest) -> HTTPClient.RequestHeaders {
+    private func headers(for request: Request, urlRequest: URLRequest) async throws -> HTTPClient.RequestHeaders {
         var headers = request.headers
 
         if request.httpRequest.path.shouldSendEtag {
@@ -578,12 +588,18 @@ private extension HTTPClient {
             headers.merge(eTagHeader)
         }
 
-        if SystemInfo.proxyURL != nil {
-            headers.mergeAdditionalHTTPHeaders(proxyAuthenticationHeadersProvider?() ?? [:])
+        if SystemInfo.proxyURL != nil, let proxyAuthenticationHeadersProvider {
+            headers.mergeAdditionalHTTPHeaders(try await proxyAuthenticationHeadersProvider())
         }
 
         headers.mergeAdditionalHTTPHeaders(jwtManager.jwtHeader())
         return headers
+    }
+
+    private func fail(request: Request, with error: NetworkError) {
+        Logger.error(error.description)
+        request.completionHandler?(.failure(error))
+        self.beginNextRequest()
     }
 
     private func signing(for request: HTTPRequest) -> SigningType {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -559,12 +559,17 @@ private extension HTTPClient {
     }
 
     func convert(request: Request) async throws -> URLRequest? {
-        guard let requestURL = request.httpRequest.path.url(proxyURL: SystemInfo.proxyURL) else {
+        let proxyURL = SystemInfo.proxyURL
+        guard let requestURL = request.httpRequest.path.url(proxyURL: proxyURL) else {
             return nil
         }
         var urlRequest = URLRequest(url: requestURL)
         urlRequest.httpMethod = request.method.httpMethod
-        urlRequest.allHTTPHeaderFields = try await self.headers(for: request, urlRequest: urlRequest)
+        urlRequest.allHTTPHeaderFields = try await self.headers(
+            for: request,
+            urlRequest: urlRequest,
+            isProxyRequest: proxyURL != nil
+        )
 
         do {
             urlRequest.httpBody = try request.httpRequest.requestBody?.jsonEncodedData
@@ -576,7 +581,11 @@ private extension HTTPClient {
         return urlRequest
     }
 
-    private func headers(for request: Request, urlRequest: URLRequest) async throws -> HTTPClient.RequestHeaders {
+    private func headers(
+        for request: Request,
+        urlRequest: URLRequest,
+        isProxyRequest: Bool
+    ) async throws -> HTTPClient.RequestHeaders {
         var headers = request.headers
 
         if request.httpRequest.path.shouldSendEtag {
@@ -588,7 +597,7 @@ private extension HTTPClient {
             headers.merge(eTagHeader)
         }
 
-        if SystemInfo.proxyURL != nil, let proxyAuthenticationHeadersProvider {
+        if isProxyRequest, let proxyAuthenticationHeadersProvider {
             headers.mergeAdditionalHTTPHeaders(try await proxyAuthenticationHeadersProvider())
         }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -218,6 +218,8 @@ import Foundation
 
         /// Set additional authentication headers for requests routed through ``Purchases/proxyURL``.
         /// The provider is evaluated for each request so short-lived account tokens can be refreshed by the app.
+        /// Returned `Cookie` values are appended to existing cookies. Other headers are added only when the SDK has
+        /// not already set the same header, so `Authorization` cannot override the RevenueCat API-key authorization.
         public func with(
             proxyAuthenticationHeadersProvider: @escaping ProxyAuthenticationHeadersProvider
         ) -> Builder {

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -37,7 +37,7 @@ import Foundation
  */
 @objc(RCConfiguration) public final class Configuration: NSObject {
 
-    public typealias ProxyAuthenticationHeadersProvider = () -> [String: String]
+    public typealias ProxyAuthenticationHeadersProvider = () async throws -> [String: String]
 
     static let storeKitRequestTimeoutDefault: TimeInterval = 30
     static let networkTimeoutDefault: TimeInterval = 60

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -37,6 +37,8 @@ import Foundation
  */
 @objc(RCConfiguration) public final class Configuration: NSObject {
 
+    public typealias ProxyAuthenticationHeadersProvider = () -> [String: String]
+
     static let storeKitRequestTimeoutDefault: TimeInterval = 30
     static let networkTimeoutDefault: TimeInterval = 60
 
@@ -51,6 +53,7 @@ import Foundation
     let platformInfo: Purchases.PlatformInfo?
     let responseVerificationMode: Signing.ResponseVerificationMode
     let showStoreMessagesAutomatically: Bool
+    let proxyAuthenticationHeadersProvider: ProxyAuthenticationHeadersProvider?
     internal let diagnosticsEnabled: Bool
 
     private init(with builder: Builder) {
@@ -67,6 +70,7 @@ import Foundation
         self.platformInfo = builder.platformInfo
         self.responseVerificationMode = builder.responseVerificationMode
         self.showStoreMessagesAutomatically = builder.showStoreMessagesAutomatically
+        self.proxyAuthenticationHeadersProvider = builder.proxyAuthenticationHeadersProvider
         self.diagnosticsEnabled = builder.diagnosticsEnabled
     }
 
@@ -98,6 +102,7 @@ import Foundation
         private(set) var platformInfo: Purchases.PlatformInfo?
         private(set) var responseVerificationMode: Signing.ResponseVerificationMode = .default
         private(set) var showStoreMessagesAutomatically: Bool = true
+        private(set) var proxyAuthenticationHeadersProvider: ProxyAuthenticationHeadersProvider?
         private(set) var diagnosticsEnabled: Bool = false
         private(set) var storeKitVersion: StoreKitVersion = .default
 
@@ -208,6 +213,15 @@ import Foundation
         /// the related methods
         @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically
+            return self
+        }
+
+        /// Set additional authentication headers for requests routed through ``Purchases/proxyURL``.
+        /// The provider is evaluated for each request so short-lived account tokens can be refreshed by the app.
+        public func with(
+            proxyAuthenticationHeadersProvider: @escaping ProxyAuthenticationHeadersProvider
+        ) -> Builder {
+            self.proxyAuthenticationHeadersProvider = proxyAuthenticationHeadersProvider
             return self
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -281,6 +281,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil,
                      showStoreMessagesAutomatically: Bool,
+                     proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider? = nil,
                      diagnosticsEnabled: Bool = false
     ) {
         if userDefaults != nil {
@@ -338,7 +339,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 productEntitlementMappingFetcher: deviceCache,
                 observerMode: observerMode
             ),
-            diagnosticsTracker: diagnosticsTracker
+            diagnosticsTracker: diagnosticsTracker,
+            proxyAuthenticationHeadersProvider: proxyAuthenticationHeadersProvider
         )
 
         let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKitVersion.isStoreKit2EnabledAndAvailable
@@ -1392,6 +1394,7 @@ public extension Purchases {
                   networkTimeout: configuration.networkTimeout,
                   dangerousSettings: configuration.dangerousSettings,
                   showStoreMessagesAutomatically: configuration.showStoreMessagesAutomatically,
+                  proxyAuthenticationHeadersProvider: configuration.proxyAuthenticationHeadersProvider,
                   diagnosticsEnabled: configuration.diagnosticsEnabled
         )
     }
@@ -1608,6 +1611,7 @@ public extension Purchases {
         networkTimeout: TimeInterval,
         dangerousSettings: DangerousSettings?,
         showStoreMessagesAutomatically: Bool,
+        proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider? = nil,
         diagnosticsEnabled: Bool
     ) -> Purchases {
         return self.setDefaultInstance(
@@ -1623,6 +1627,7 @@ public extension Purchases {
                   networkTimeout: networkTimeout,
                   dangerousSettings: dangerousSettings,
                   showStoreMessagesAutomatically: showStoreMessagesAutomatically,
+                  proxyAuthenticationHeadersProvider: proxyAuthenticationHeadersProvider,
                   diagnosticsEnabled: diagnosticsEnabled)
         )
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -64,14 +64,17 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
 
     fileprivate final func createClient(
         _ systemInfo: SystemInfo,
+        jwtManager: JWTManager = JWTManager(),
+        proxyAuthenticationHeadersProvider: Configuration.ProxyAuthenticationHeadersProvider? = nil,
         operationDispatcher: OperationDispatcher = MockOperationDispatcher()
     ) -> HTTPClient {
         return HTTPClient(apiKey: self.apiKey,
                           systemInfo: systemInfo,
                           eTagManager: self.eTagManager,
-                          jwtManager: JWTManager(),
+                          jwtManager: jwtManager,
                           signing: self.signing,
                           diagnosticsTracker: self.diagnosticsTracker,
+                          proxyAuthenticationHeadersProvider: proxyAuthenticationHeadersProvider,
                           dnsChecker: MockDNSChecker.self,
                           requestTimeout: defaultTimeout.seconds,
                           operationDispatcher: operationDispatcher)
@@ -119,6 +122,101 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         expect(headerPresent.value) == true
+    }
+
+    func testPassesProxyAuthenticationHeadersWhenProxyURLIsConfigured() throws {
+        let proxyURL = try XCTUnwrap(URL(string: "https://proxy.goodnotes.test"))
+        SystemInfo.proxyURL = proxyURL
+        defer { SystemInfo.proxyURL = nil }
+
+        self.client = self.createClient(
+            self.systemInfo,
+            proxyAuthenticationHeadersProvider: {
+                [
+                    "Authorization": "Bearer goodnotes-session",
+                    "Cookie": "ory_kratos_session=session; gnc_accounts_jwt=account-jwt"
+                ]
+            }
+        )
+
+        let request = HTTPRequest(method: .get, path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isHost(proxyURL.host!) && isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers?["Authorization"]) == "Bearer \(self.apiKey)"
+        expect(headers?["Cookie"]).to(contain("ory_kratos_session=session"))
+        expect(headers?["Cookie"]).to(contain("gnc_accounts_jwt=account-jwt"))
+    }
+
+    func testDoesNotEvaluateProxyAuthenticationHeadersWhenProxyURLIsNotConfigured() {
+        let providerCalls: Atomic<Int> = 0
+        self.client = self.createClient(
+            self.systemInfo,
+            proxyAuthenticationHeadersProvider: {
+                providerCalls.modify { $0 += 1 }
+                return ["Cookie": "ory_kratos_session=session"]
+            }
+        )
+
+        let request = HTTPRequest(method: .get, path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(providerCalls.value) == 0
+        expect(headers?["Cookie"]).to(beNil())
+    }
+
+    func testMergesProxyAuthenticationCookiesWithStoredJWT() throws {
+        let proxyURL = try XCTUnwrap(URL(string: "https://proxy.goodnotes.test"))
+        SystemInfo.proxyURL = proxyURL
+        defer { SystemInfo.proxyURL = nil }
+
+        let jwtManager = JWTManager(userDefaults: try XCTUnwrap(UserDefaults(suiteName: UUID().uuidString)))
+        let isiToken = Self.validJWTToken()
+        let response = try XCTUnwrap(HTTPURLResponse(
+            url: proxyURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Set-Cookie": "isi_token=\(isiToken); Path=/"]
+        ))
+        jwtManager.store(from: response)
+
+        self.client = self.createClient(
+            self.systemInfo,
+            jwtManager: jwtManager,
+            proxyAuthenticationHeadersProvider: {
+                ["Cookie": "ory_kratos_session=session; gnc_accounts_jwt=account-jwt"]
+            }
+        )
+
+        let request = HTTPRequest(method: .get, path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isHost(proxyURL.host!) && isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers?["Cookie"]).to(contain("ory_kratos_session=session"))
+        expect(headers?["Cookie"]).to(contain("gnc_accounts_jwt=account-jwt"))
+        expect(headers?["Cookie"]).to(contain("isi_token=\(isiToken)"))
     }
 
     func testRequestWithNoNonceDoesNotContainNonceHeader() {
@@ -1726,6 +1824,17 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             nil,
             .notRequested
         )))
+    }
+
+    private static func validJWTToken() -> String {
+        let payload = #"{"exp":4102444800}"#
+        let encodedPayload = Data(payload.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        return "e30.\(encodedPayload).signature"
     }
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -156,7 +156,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
     }
 
     func testDoesNotEvaluateProxyAuthenticationHeadersWhenProxyURLIsNotConfigured() {
-        let providerCalls: Atomic<Int> = 0
+        let providerCalls: Atomic<Int> = .init(0)
         self.client = self.createClient(
             self.systemInfo,
             proxyAuthenticationHeadersProvider: {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -155,6 +155,82 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headers?["Cookie"]).to(contain("gnc_accounts_jwt=account-jwt"))
     }
 
+    func testAwaitsProxyAuthenticationHeadersForEveryProxiedRequest() throws {
+        let proxyURL = try XCTUnwrap(URL(string: "https://proxy.goodnotes.test"))
+        SystemInfo.proxyURL = proxyURL
+        defer { SystemInfo.proxyURL = nil }
+
+        let providerCalls: Atomic<Int> = .init(0)
+        let receivedHeaders: Atomic<[[String: String]]> = .init([])
+        self.client = self.createClient(
+            self.systemInfo,
+            proxyAuthenticationHeadersProvider: {
+                let requestNumber = providerCalls.modify { calls in
+                    calls += 1
+                    return calls
+                }
+                try await Task.sleep(nanoseconds: 1_000_000)
+                return ["Cookie": "gnc_accounts_jwt=account-jwt-\(requestNumber)"]
+            }
+        )
+
+        let request = HTTPRequest(method: .get, path: .mockPath)
+
+        stub(condition: isHost(proxyURL.host!) && isPath(request.path)) { request in
+            receivedHeaders.modify { headers in
+                headers.append(request.allHTTPHeaderFields ?? [:])
+            }
+            return .emptySuccessResponse()
+        }
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
+        }
+        waitUntil { completion in
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
+        }
+
+        expect(providerCalls.value) == 2
+        expect(receivedHeaders.value[safe: 0]?["Cookie"]).to(contain("gnc_accounts_jwt=account-jwt-1"))
+        expect(receivedHeaders.value[safe: 1]?["Cookie"]).to(contain("gnc_accounts_jwt=account-jwt-2"))
+    }
+
+    func testFailsProxiedRequestWhenProxyAuthenticationHeadersProviderThrows() throws {
+        let proxyURL = try XCTUnwrap(URL(string: "https://proxy.goodnotes.test"))
+        SystemInfo.proxyURL = proxyURL
+        defer { SystemInfo.proxyURL = nil }
+
+        let providerError = NSError(domain: "ProxyAuthenticationHeadersProvider", code: 1)
+        let didReachServer: Atomic<Bool> = .init(false)
+        self.client = self.createClient(
+            self.systemInfo,
+            proxyAuthenticationHeadersProvider: {
+                throw providerError
+            }
+        )
+
+        let request = HTTPRequest(method: .get, path: .mockPath)
+        stub(condition: isHost(proxyURL.host!) && isPath(request.path)) { _ in
+            didReachServer.value = true
+            return .emptySuccessResponse()
+        }
+
+        let receivedError: NetworkError? = waitUntilValue { completion in
+            self.client.perform(request) { (result: EmptyResponse) in
+                completion(result.error)
+            }
+        }
+
+        expect(didReachServer.value) == false
+        switch receivedError {
+        case let .networkError(actualError, _):
+            expect(actualError.domain) == providerError.domain
+            expect(actualError.code) == providerError.code
+        default:
+            fail("Unexpected error: \(String(describing: receivedError))")
+        }
+    }
+
     func testDoesNotEvaluateProxyAuthenticationHeadersWhenProxyURLIsNotConfigured() {
         let providerCalls: Atomic<Int> = .init(0)
         self.client = self.createClient(


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
MNA-3854 requires Goodnotes iOS requests routed through the RevenueCat proxy to include Goodnotes account authentication so the backend can validate subscriber access.

### Description
Changes `Configuration.ProxyAuthenticationHeadersProvider` to an async throwing provider so the app can fetch or refresh credentials immediately before a proxied RevenueCat request is sent.

`HTTPClient` now evaluates the provider only when `proxyURL` is configured, and it does so for every proxied request while converting the SDK request into a `URLRequest`. The request conversion snapshots the proxy state once, then uses that same value for URL construction and header selection. If the provider throws, the request fails locally with a `networkError` instead of being sent without required proxy auth.

Header merge behavior is preserved for safe proxy use: returned `Cookie` values are appended to existing cookies, while non-cookie headers are only added when the SDK has not already set that header. This keeps `Authorization: Bearer <RevenueCat API key>` intact and lets the Goodnotes app send account auth as `Cookie: ory_kratos_session=<session>; gnc_accounts_jwt=<jwt>` or `Cookie: gnc_accounts_jwt=<jwt>`.

Covered by `HTTPClientTests` for proxy-only evaluation, awaiting fresh auth headers per proxied request, provider failure handling, auth header forwarding, and cookie merging.

Testing:
- `swift build`
- `xcodebuild test -project RevenueCat.xcodeproj -scheme RevenueCat -destination 'id=1933D538-3AEF-41F9-99E2-142B6507DC93' -only-testing:UnitTests/HTTPClientTests/testPassesProxyAuthenticationHeadersWhenProxyURLIsConfigured -only-testing:UnitTests/HTTPClientTests/testAwaitsProxyAuthenticationHeadersForEveryProxiedRequest -only-testing:UnitTests/HTTPClientTests/testFailsProxiedRequestWhenProxyAuthenticationHeadersProviderThrows -only-testing:UnitTests/HTTPClientTests/testDoesNotEvaluateProxyAuthenticationHeadersWhenProxyURLIsNotConfigured -only-testing:UnitTests/HTTPClientTests/testMergesProxyAuthenticationCookiesWithStoredJWT`
